### PR TITLE
Fix contact menu initialization errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,27 +24,27 @@
         <ul class="contact-menu__list">
             <li class="contact-menu__list-item">
                 <a class="contact-menu__link" href="https://diafestivo.co/" target="_blank"
-                    aria-label="Link To diafestivo.co">Diafestivo</a>
+                    rel="noopener noreferrer" aria-label="Link To diafestivo.co">Diafestivo</a>
             </li>
             <li class="contact-menu__list-item">
                 <a class="contact-menu__link" href="https://www.linkedin.com/in/sanetomore"
-                    target="_blank" aria-label="Link to Andres LinkedIn">Linkedin</a>
+                    target="_blank" rel="noopener noreferrer" aria-label="Link to Andres LinkedIn">Linkedin</a>
             </li>
             <li class="contact-menu__list-item">
                 <a class="contact-menu__link" href="https://www.instagram.com/sanetomore" target="_blank"
-                    aria-label="Link to Andres Instagram">Instagram</a>
+                    rel="noopener noreferrer" aria-label="Link to Andres Instagram">Instagram</a>
             </li>
             <li class="contact-menu__list-item">
                 <a class="contact-menu__link" href="https://github.com/SomeoneWithOptions" target="_blank"
-                    aria-label="Link to Andres Github">GitHub</a>
+                    rel="noopener noreferrer" aria-label="Link to Andres Github">GitHub</a>
             </li>
             <li class="contact-menu__list-item">
                 <a class="contact-menu__link" href="mailto:acastesol@gmail.com" target="_blank"
-                    aria-label="Link to Andres Email">Email</a>
+                    rel="noopener noreferrer" aria-label="Link to Andres Email">Email</a>
             </li>
             <li class="contact-menu__list-item">
                 <a class="contact-menu__link" href="https://cal.com/sanetomore" target="_blank"
-                    aria-label="Link To Andres Calendar">Lets Talk!</a>
+                    rel="noopener noreferrer" aria-label="Link To Andres Calendar">Lets Talk!</a>
             </li>
         </ul>
     </div>
@@ -57,7 +57,7 @@
             <h1 class="page-1__title">Andres Castellanos</h1>
             <div class="page-1__paragraph">
                 <p>Hey! I'm an IT Admin with 8+ years of experience</p>
-                <p>Currently working at <a href="https://recurly.com/">Recurly</a></p>
+                <p>Currently working at <a href="https://recurly.com/" rel="noopener noreferrer">Recurly</a></p>
                 <p>I love Drumming, Running and lately working on Web Projects.</p>
             </div>
         </div>

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -1,13 +1,28 @@
-
-
-const contactLink = document.querySelector(".page-1__header__menu")
+const contactLink = document.querySelector(".page-1__header__menu");
 const contactMenu = document.querySelector(".contact-menu");
-function toggleMenu() {
-    contactMenu.classList.toggle("contact-menu--active"), contactMenu.classList.toggle("contact-menu--inactive");
+
+if (contactLink && contactMenu) {
+    const toggleMenu = () => {
+        contactMenu.classList.toggle("contact-menu--active");
+        contactMenu.classList.toggle("contact-menu--inactive");
+    };
+
+    if (!contactMenu.classList.contains("contact-menu--inactive")) {
+        contactMenu.classList.add("contact-menu--inactive");
+    }
+
+    contactLink.addEventListener("click", (event) => {
+        if (contactMenu.classList.contains("contact-menu--inactive")) {
+            toggleMenu();
+        }
+
+        contactMenu.classList.add("contact-menu--active");
+        event.stopPropagation();
+    });
+
+    window.addEventListener("click", () => {
+        if (contactMenu.classList.contains("contact-menu--active")) {
+            toggleMenu();
+        }
+    });
 }
-contactLink.addEventListener("click", function (t) {
-    contactMenu.classList.contains("contact-menu--inactive") && toggleMenu(), contactMenu.classList.add("contact-menu--active"), t.stopPropagation();
-})
-window.addEventListener("click", function (t) {
-    contactMenu.classList.contains("contact-menu--active") && toggleMenu();
-});


### PR DESCRIPTION
## Summary
- guard the contact menu script so it only runs when the markup is present
- ensure the menu starts in its hidden state before listeners fire
- add noopener security attributes to external links

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe9f3aca1c8333b23f4431f4dff0c9