### PR TITLE
Improve contact menu accessibility and toggle logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
 </head>
 
 <body>
-    <div class="contact-menu" data-show="false">
+    <div class="contact-menu contact-menu--inactive" aria-hidden="true">
         <ul class="contact-menu__list">
             <li class="contact-menu__list-item">
                 <a class="contact-menu__link" href="https://diafestivo.co/" target="_blank"
@@ -52,7 +52,7 @@
     <div class="page-1">
         <div class="page-1__container">
             <header class="page-1__header">
-                <span class="page-1__header__menu">Contact</span>
+                <button class="page-1__header__menu" type="button">Contact</button>
             </header>
             <h1 class="page-1__title">Andres Castellanos</h1>
             <div class="page-1__paragraph">

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -1,13 +1,56 @@
-
-
-const contactLink = document.querySelector(".page-1__header__menu")
+const contactLink = document.querySelector(".page-1__header__menu");
 const contactMenu = document.querySelector(".contact-menu");
-function toggleMenu() {
-    contactMenu.classList.toggle("contact-menu--active"), contactMenu.classList.toggle("contact-menu--inactive");
+
+if (contactLink && contactMenu) {
+    const ACTIVE_CLASS = "contact-menu--active";
+    const INACTIVE_CLASS = "contact-menu--inactive";
+
+    const isMenuOpen = () => contactMenu.classList.contains(ACTIVE_CLASS);
+
+    const openMenu = () => {
+        contactMenu.classList.add(ACTIVE_CLASS);
+        contactMenu.classList.remove(INACTIVE_CLASS);
+        contactMenu.setAttribute("aria-hidden", "false");
+    };
+
+    const closeMenu = () => {
+        contactMenu.classList.remove(ACTIVE_CLASS);
+        contactMenu.classList.add(INACTIVE_CLASS);
+        contactMenu.setAttribute("aria-hidden", "true");
+    };
+
+    const toggleMenu = () => {
+        if (isMenuOpen()) {
+            closeMenu();
+            return;
+        }
+
+        openMenu();
+    };
+
+    closeMenu();
+
+    contactLink.addEventListener("click", (event) => {
+        toggleMenu();
+        event.stopPropagation();
+    });
+
+    window.addEventListener("click", (event) => {
+        if (!isMenuOpen()) {
+            return;
+        }
+
+        const clickedInsideMenu = contactMenu.contains(event.target);
+        const clickedOnToggle = contactLink.contains(event.target);
+
+        if (!clickedInsideMenu && !clickedOnToggle) {
+            closeMenu();
+        }
+    });
+
+    window.addEventListener("keydown", (event) => {
+        if (event.key === "Escape" && isMenuOpen()) {
+            closeMenu();
+        }
+    });
 }
-contactLink.addEventListener("click", function (t) {
-    contactMenu.classList.contains("contact-menu--inactive") && toggleMenu(), contactMenu.classList.add("contact-menu--active"), t.stopPropagation();
-})
-window.addEventListener("click", function (t) {
-    contactMenu.classList.contains("contact-menu--active") && toggleMenu();
-});

--- a/styles/main.css
+++ b/styles/main.css
@@ -244,10 +244,14 @@ body {
 }
 
 .page-1__header__menu {
+    background: none;
+    border: 0;
+    color: inherit;
     cursor: pointer;
     text-shadow: 3px 3px 0 rgba(0, 0, 0, .25);
     font-size: 1.5rem;
-    margin-right: 5%
+    margin-right: 5%;
+    padding: 0;
 }
 
 .page-1__paragraph {


### PR DESCRIPTION
## Summary
- ensure the contact menu starts hidden with accessibility metadata
- harden the contact toggle script with explicit open/close logic and escape handling
- convert the contact toggle into a button and reset default button styles

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ff55d9d0ec8333b82d2e7c06662886